### PR TITLE
Implement remote result retrieval

### DIFF
--- a/NetProject.Tests/RemoteResultTests.cs
+++ b/NetProject.Tests/RemoteResultTests.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NetProject;
+using Xunit;
+
+public class RemoteResultTests
+{
+    private class FakeHttpHandler : HttpMessageHandler
+    {
+        private readonly string _content;
+        public FakeHttpHandler(string content) => _content = content;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_content)
+            });
+        }
+    }
+
+    private class FakePresenter : IMessagePresenter
+    {
+        public string? Message;
+        public void ShowMessage(string message) => Message = message;
+    }
+
+    [Fact]
+    public void ShowRemoteResult_DisplaysFetchedContent()
+    {
+        var handler = new FakeHttpHandler("expected result");
+        var httpClient = new HttpClient(handler);
+        var reader = new ResultReader(httpClient);
+        var presenter = new FakePresenter();
+
+        Program.ShowRemoteResult(presenter, reader);
+
+        Assert.Equal("expected result", presenter.Message);
+    }
+}

--- a/NetProject/Program.vb
+++ b/NetProject/Program.vb
@@ -11,6 +11,7 @@ Public Module Program
 
     Sub Main()
         ShowGreeting()
+        ShowRemoteResult()
     End Sub
 
     Public Sub ShowGreeting(Optional customPresenter As IMessagePresenter = Nothing)
@@ -20,5 +21,12 @@ Public Module Program
         Else
             messagePresenter.ShowMessage(greeting)
         End If
+    End Sub
+
+    Public Sub ShowRemoteResult(Optional customPresenter As IMessagePresenter = Nothing, Optional reader As ResultReader = Nothing)
+        Dim presenter As IMessagePresenter = If(customPresenter, messagePresenter)
+        Dim resultReader As ResultReader = If(reader, New ResultReader())
+        Dim remoteResult As String = resultReader.FetchRemoteResultAsync().Result
+        presenter.ShowMessage(remoteResult)
     End Sub
 End Module

--- a/NetProject/ResultReader.vb
+++ b/NetProject/ResultReader.vb
@@ -1,0 +1,23 @@
+' 2025-06-07
+' Fetches remote build results from NetPipeRemoteDotNet
+' Author: Codex
+' Created: 2025-06-07
+' Edited: 2025-06-07
+
+Imports System.Net.Http
+Imports System.Threading.Tasks
+
+Public Class ResultReader
+    Private ReadOnly httpClient As HttpClient
+    Private Const ResultUrl As String = "http://t78.ch/apps/netpipe/result.ashx"
+
+    Public Sub New(Optional customClient As HttpClient = Nothing)
+        httpClient = If(customClient, New HttpClient())
+    End Sub
+
+    Public Async Function FetchRemoteResultAsync() As Task(Of String)
+        Dim response As HttpResponseMessage = Await httpClient.GetAsync(ResultUrl)
+        response.EnsureSuccessStatusCode()
+        Return Await response.Content.ReadAsStringAsync()
+    End Function
+End Class


### PR DESCRIPTION
## Summary
- add `ResultReader` to fetch results from NetPipeRemoteDotNet
- display remote result in `Program.ShowRemoteResult`
- test `ShowRemoteResult` using fake `HttpClient`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f07a09908333a3cd632cb317c62e