### PR TITLE
Add build status checker

### DIFF
--- a/NetProject.Tests/BuildStatusTests.cs
+++ b/NetProject.Tests/BuildStatusTests.cs
@@ -1,0 +1,31 @@
+using NetProject;
+using System.Threading.Tasks;
+using Xunit;
+
+public class BuildStatusTests
+{
+    private class FakeReader : ResultReader
+    {
+        private readonly string _content;
+        public FakeReader(string content) : base(null)
+        {
+            _content = content;
+        }
+        public override async Task<string> FetchRemoteResultAsync()
+        {
+            await Task.CompletedTask;
+            return _content;
+        }
+    }
+
+    [Fact]
+    public async Task GetCurrentStatusAsync_ReturnsSuccessWhenExitCodeZero()
+    {
+        var content = "something\nExit code: 0\nmore";
+        var reader = new FakeReader(content);
+        var checker = new BuildStatusChecker(reader);
+        BuildStatus status = await checker.GetCurrentStatusAsync();
+        Assert.True(status.IsSuccess);
+        Assert.Equal(0, status.ExitCode);
+    }
+}

--- a/NetProject/BuildStatusChecker.vb
+++ b/NetProject/BuildStatusChecker.vb
@@ -1,0 +1,53 @@
+' 2025-06-07
+' Determines build status from remote result file
+' Author: Codex
+' Created: 2025-06-07
+' Edited: 2025-06-07
+
+Imports System.Threading.Tasks
+
+Public Class BuildStatus
+    Public ReadOnly Property ExitCode As Integer
+    Public ReadOnly Property RawOutput As String
+
+    Public Sub New(code As Integer, raw As String)
+        ExitCode = code
+        RawOutput = raw
+    End Sub
+
+    Public ReadOnly Property IsSuccess As Boolean
+        Get
+            Return ExitCode = 0
+        End Get
+    End Property
+End Class
+
+Public Class BuildStatusChecker
+    Private ReadOnly resultReader As ResultReader
+
+    Public Sub New(Optional reader As ResultReader = Nothing)
+        resultReader = If(reader, New ResultReader())
+    End Sub
+
+    Public Async Function GetCurrentStatusAsync() As Task(Of BuildStatus)
+        Dim content As String = Await resultReader.FetchRemoteResultAsync()
+        Dim code As Integer = ParseExitCode(content)
+        Return New BuildStatus(code, content)
+    End Function
+
+    Private Function ParseExitCode(content As String) As Integer
+        Const pattern As String = "Exit code:"
+        Dim index As Integer = content.IndexOf(pattern)
+        If index <> -1 Then
+            index += pattern.Length
+            Dim lineEnd As Integer = content.IndexOfAny(New Char() {Chr(10), Chr(13)}, index)
+            If lineEnd = -1 Then lineEnd = content.Length
+            Dim numberString As String = content.Substring(index, lineEnd - index).Trim()
+            Dim result As Integer
+            If Integer.TryParse(numberString, result) Then
+                Return result
+            End If
+        End If
+        Return -1
+    End Function
+End Class

--- a/NetProject/ResultReader.vb
+++ b/NetProject/ResultReader.vb
@@ -15,7 +15,7 @@ Public Class ResultReader
         httpClient = If(customClient, New HttpClient())
     End Sub
 
-    Public Async Function FetchRemoteResultAsync() As Task(Of String)
+    Public Overridable Async Function FetchRemoteResultAsync() As Task(Of String)
         Dim response As HttpResponseMessage = Await httpClient.GetAsync(ResultUrl)
         response.EnsureSuccessStatusCode()
         Return Await response.Content.ReadAsStringAsync()


### PR DESCRIPTION
## Summary
- add a `BuildStatusChecker` to determine if the remote build succeeded
- make `ResultReader.FetchRemoteResultAsync` overridable for testing
- test build status parsing

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684438a997188333a50fa7cfa3d775e9