### PR TITLE
Refactor result handling

### DIFF
--- a/NetProject.Tests/BuildStatusParserTests.cs
+++ b/NetProject.Tests/BuildStatusParserTests.cs
@@ -1,0 +1,13 @@
+using NetProject;
+using Xunit;
+
+public class BuildStatusParserTests
+{
+    [Fact]
+    public void ParseExitCode_ReturnsNumber()
+    {
+        var parser = new BuildStatusParser();
+        int code = parser.ParseExitCode("some text\nExit code: 1\nnext");
+        Assert.Equal(1, code);
+    }
+}

--- a/NetProject/BuildStatus.vb
+++ b/NetProject/BuildStatus.vb
@@ -1,0 +1,21 @@
+' 2025-06-07
+' Determines build status from remote result file
+' Author: Codex
+' Created: 2025-06-07
+' Edited: 2025-06-07
+
+Public Class BuildStatus
+    Public ReadOnly Property ExitCode As Integer
+    Public ReadOnly Property RawOutput As String
+
+    Public Sub New(code As Integer, raw As String)
+        ExitCode = code
+        RawOutput = raw
+    End Sub
+
+    Public ReadOnly Property IsSuccess As Boolean
+        Get
+            Return ExitCode = 0
+        End Get
+    End Property
+End Class

--- a/NetProject/BuildStatusChecker.vb
+++ b/NetProject/BuildStatusChecker.vb
@@ -6,48 +6,17 @@
 
 Imports System.Threading.Tasks
 
-Public Class BuildStatus
-    Public ReadOnly Property ExitCode As Integer
-    Public ReadOnly Property RawOutput As String
-
-    Public Sub New(code As Integer, raw As String)
-        ExitCode = code
-        RawOutput = raw
-    End Sub
-
-    Public ReadOnly Property IsSuccess As Boolean
-        Get
-            Return ExitCode = 0
-        End Get
-    End Property
-End Class
-
 Public Class BuildStatusChecker
-    Private ReadOnly resultReader As ResultReader
+    Private ReadOnly resultReader As IResultReader
 
-    Public Sub New(Optional reader As ResultReader = Nothing)
+    Public Sub New(Optional reader As IResultReader = Nothing)
         resultReader = If(reader, New ResultReader())
     End Sub
 
     Public Async Function GetCurrentStatusAsync() As Task(Of BuildStatus)
         Dim content As String = Await resultReader.FetchRemoteResultAsync()
-        Dim code As Integer = ParseExitCode(content)
+        Dim parser As New BuildStatusParser()
+        Dim code As Integer = parser.ParseExitCode(content)
         Return New BuildStatus(code, content)
-    End Function
-
-    Private Function ParseExitCode(content As String) As Integer
-        Const pattern As String = "Exit code:"
-        Dim index As Integer = content.IndexOf(pattern)
-        If index <> -1 Then
-            index += pattern.Length
-            Dim lineEnd As Integer = content.IndexOfAny(New Char() {Chr(10), Chr(13)}, index)
-            If lineEnd = -1 Then lineEnd = content.Length
-            Dim numberString As String = content.Substring(index, lineEnd - index).Trim()
-            Dim result As Integer
-            If Integer.TryParse(numberString, result) Then
-                Return result
-            End If
-        End If
-        Return -1
     End Function
 End Class

--- a/NetProject/BuildStatusParser.vb
+++ b/NetProject/BuildStatusParser.vb
@@ -1,0 +1,23 @@
+' 2025-06-07
+' Parses result text into exit codes
+' Author: Codex
+' Created: 2025-06-07
+' Edited: 2025-06-07
+
+Public Class BuildStatusParser
+    Public Function ParseExitCode(content As String) As Integer
+        Const pattern As String = "Exit code:"
+        Dim index As Integer = content.IndexOf(pattern)
+        If index <> -1 Then
+            index += pattern.Length
+            Dim lineEnd As Integer = content.IndexOfAny(New Char() {Chr(10), Chr(13)}, index)
+            If lineEnd = -1 Then lineEnd = content.Length
+            Dim numberString As String = content.Substring(index, lineEnd - index).Trim()
+            Dim result As Integer
+            If Integer.TryParse(numberString, result) Then
+                Return result
+            End If
+        End If
+        Return -1
+    End Function
+End Class

--- a/NetProject/IResultReader.vb
+++ b/NetProject/IResultReader.vb
@@ -1,0 +1,11 @@
+' 2025-06-07
+' Provides abstraction for reading remote results
+' Author: Codex
+' Created: 2025-06-07
+' Edited: 2025-06-07
+
+Imports System.Threading.Tasks
+
+Public Interface IResultReader
+    Function FetchRemoteResultAsync() As Task(Of String)
+End Interface

--- a/NetProject/Program.vb
+++ b/NetProject/Program.vb
@@ -23,9 +23,9 @@ Public Module Program
         End If
     End Sub
 
-    Public Sub ShowRemoteResult(Optional customPresenter As IMessagePresenter = Nothing, Optional reader As ResultReader = Nothing)
+    Public Sub ShowRemoteResult(Optional customPresenter As IMessagePresenter = Nothing, Optional reader As IResultReader = Nothing)
         Dim presenter As IMessagePresenter = If(customPresenter, messagePresenter)
-        Dim resultReader As ResultReader = If(reader, New ResultReader())
+        Dim resultReader As IResultReader = If(reader, New ResultReader())
         Dim remoteResult As String = resultReader.FetchRemoteResultAsync().Result
         presenter.ShowMessage(remoteResult)
     End Sub

--- a/NetProject/ResultReader.vb
+++ b/NetProject/ResultReader.vb
@@ -8,6 +8,7 @@ Imports System.Net.Http
 Imports System.Threading.Tasks
 
 Public Class ResultReader
+    Implements IResultReader
     Private ReadOnly httpClient As HttpClient
     Private Const ResultUrl As String = "http://t78.ch/apps/netpipe/result.ashx"
 
@@ -15,7 +16,8 @@ Public Class ResultReader
         httpClient = If(customClient, New HttpClient())
     End Sub
 
-    Public Overridable Async Function FetchRemoteResultAsync() As Task(Of String)
+    Public Overridable Async Function FetchRemoteResultAsync() As Task(Of String) _
+        Implements IResultReader.FetchRemoteResultAsync
         Dim response As HttpResponseMessage = Await httpClient.GetAsync(ResultUrl)
         response.EnsureSuccessStatusCode()
         Return Await response.Content.ReadAsStringAsync()


### PR DESCRIPTION
## Summary
- add interface `IResultReader`
- introduce `BuildStatusParser` and move `BuildStatus` to its own file
- update `BuildStatusChecker` and `Program` to use the new abstractions
- add a small unit test for the parser

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449389a93c83338dc3fbd3073eb739