### PR TITLE
Add build status size parsing

### DIFF
--- a/NetProject.Tests/BuildStatusDisplayTests.cs
+++ b/NetProject.Tests/BuildStatusDisplayTests.cs
@@ -2,7 +2,7 @@ using NetProject;
 using System.Threading.Tasks;
 using Xunit;
 
-public class BuildStatusTests
+public class BuildStatusDisplayTests
 {
     private class FakeReader : ResultReader
     {
@@ -18,15 +18,22 @@ public class BuildStatusTests
         }
     }
 
-    [Fact]
-    public async Task GetCurrentStatusAsync_ReturnsSuccessWhenExitCodeZero()
+    private class FakePresenter : IMessagePresenter
     {
-        var content = "something\nExit code: 0\nFile size: 42\nmore";
+        public string? Message;
+        public void ShowMessage(string message) => Message = message;
+    }
+
+    [Fact]
+    public void ShowBuildStatus_DisplaysParsedInfo()
+    {
+        var content = "Exit code: 1\nFile size: 5";
         var reader = new FakeReader(content);
         var checker = new BuildStatusChecker(reader);
-        BuildStatus status = await checker.GetCurrentStatusAsync();
-        Assert.True(status.IsSuccess);
-        Assert.Equal(0, status.ExitCode);
-        Assert.Equal(42, status.FileSize);
+        var presenter = new FakePresenter();
+
+        Program.ShowBuildStatus(presenter, checker);
+
+        Assert.Equal("Exit code: 1, Size: 5", presenter.Message);
     }
 }

--- a/NetProject.Tests/BuildStatusParserTests.cs
+++ b/NetProject.Tests/BuildStatusParserTests.cs
@@ -10,4 +10,12 @@ public class BuildStatusParserTests
         int code = parser.ParseExitCode("some text\nExit code: 1\nnext");
         Assert.Equal(1, code);
     }
+
+    [Fact]
+    public void ParseFileSize_ReturnsNumber()
+    {
+        var parser = new BuildStatusParser();
+        long size = parser.ParseFileSize("info\nFile size: 99 bytes\nend");
+        Assert.Equal(99, size);
+    }
 }

--- a/NetProject/BuildStatus.vb
+++ b/NetProject/BuildStatus.vb
@@ -1,16 +1,18 @@
-' 2025-06-07
+' 2025-06-08
 ' Determines build status from remote result file
 ' Author: Codex
 ' Created: 2025-06-07
-' Edited: 2025-06-07
+' Edited: 2025-06-08
 
 Public Class BuildStatus
     Public ReadOnly Property ExitCode As Integer
     Public ReadOnly Property RawOutput As String
+    Public ReadOnly Property FileSize As Long
 
-    Public Sub New(code As Integer, raw As String)
+    Public Sub New(code As Integer, raw As String, Optional size As Long = -1)
         ExitCode = code
         RawOutput = raw
+        FileSize = size
     End Sub
 
     Public ReadOnly Property IsSuccess As Boolean

--- a/NetProject/BuildStatusChecker.vb
+++ b/NetProject/BuildStatusChecker.vb
@@ -1,8 +1,8 @@
-' 2025-06-07
+' 2025-06-08
 ' Determines build status from remote result file
 ' Author: Codex
 ' Created: 2025-06-07
-' Edited: 2025-06-07
+' Edited: 2025-06-08
 
 Imports System.Threading.Tasks
 
@@ -17,6 +17,7 @@ Public Class BuildStatusChecker
         Dim content As String = Await resultReader.FetchRemoteResultAsync()
         Dim parser As New BuildStatusParser()
         Dim code As Integer = parser.ParseExitCode(content)
-        Return New BuildStatus(code, content)
+        Dim size As Long = parser.ParseFileSize(content)
+        Return New BuildStatus(code, content, size)
     End Function
 End Class

--- a/NetProject/BuildStatusParser.vb
+++ b/NetProject/BuildStatusParser.vb
@@ -1,8 +1,8 @@
-' 2025-06-07
-' Parses result text into exit codes
+' 2025-06-08
+' Parses result text into build details
 ' Author: Codex
 ' Created: 2025-06-07
-' Edited: 2025-06-07
+' Edited: 2025-06-08
 
 Public Class BuildStatusParser
     Public Function ParseExitCode(content As String) As Integer
@@ -15,6 +15,24 @@ Public Class BuildStatusParser
             Dim numberString As String = content.Substring(index, lineEnd - index).Trim()
             Dim result As Integer
             If Integer.TryParse(numberString, result) Then
+                Return result
+            End If
+        End If
+        Return -1
+    End Function
+
+    Public Function ParseFileSize(content As String) As Long
+        Const pattern As String = "File size:"
+        Dim index As Integer = content.IndexOf(pattern, StringComparison.OrdinalIgnoreCase)
+        If index <> -1 Then
+            index += pattern.Length
+            Dim lineEnd As Integer = content.IndexOfAny(New Char() {Chr(10), Chr(13)}, index)
+            If lineEnd = -1 Then lineEnd = content.Length
+            Dim numberString As String = content.Substring(index, lineEnd - index).Trim()
+            numberString = numberString.Replace("bytes", "", StringComparison.OrdinalIgnoreCase).Trim()
+            numberString = numberString.Replace("byte", "", StringComparison.OrdinalIgnoreCase).Trim()
+            Dim result As Long
+            If Long.TryParse(numberString, result) Then
                 Return result
             End If
         End If

--- a/NetProject/Program.vb
+++ b/NetProject/Program.vb
@@ -1,8 +1,8 @@
-' 2025-06-07 XXX
+' 2025-06-08 XXX
 ' Entry point of application
 ' Author: Codex
 ' Created: 2025-06-07
-' Edited: 2025-06-07
+' Edited: 2025-06-08
 
 Imports System.Windows.Forms
 
@@ -12,6 +12,7 @@ Public Module Program
     Sub Main()
         ShowGreeting()
         ShowRemoteResult()
+        ShowBuildStatus()
     End Sub
 
     Public Sub ShowGreeting(Optional customPresenter As IMessagePresenter = Nothing)
@@ -28,5 +29,13 @@ Public Module Program
         Dim resultReader As IResultReader = If(reader, New ResultReader())
         Dim remoteResult As String = resultReader.FetchRemoteResultAsync().Result
         presenter.ShowMessage(remoteResult)
+    End Sub
+
+    Public Sub ShowBuildStatus(Optional customPresenter As IMessagePresenter = Nothing, Optional checker As BuildStatusChecker = Nothing)
+        Dim presenter As IMessagePresenter = If(customPresenter, messagePresenter)
+        Dim statusChecker As BuildStatusChecker = If(checker, New BuildStatusChecker())
+        Dim status As BuildStatus = statusChecker.GetCurrentStatusAsync().Result
+        Dim message As String = $"Exit code: {status.ExitCode}, Size: {status.FileSize}"
+        presenter.ShowMessage(message)
     End Sub
 End Module


### PR DESCRIPTION
## Summary
- parse file size from result text
- store file size in `BuildStatus`
- expose build status via `ShowBuildStatus`
- test new parsing and display logic

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844992c07788333ab897beaf31be4c2