### PR TITLE
Add web browser tab support

### DIFF
--- a/NetProject.Tests/BrowserTests.cs
+++ b/NetProject.Tests/BrowserTests.cs
@@ -1,0 +1,19 @@
+using NetProject;
+using Xunit;
+
+public class BrowserTests
+{
+    private class FakeBrowser : IBrowserService
+    {
+        public string? Url;
+        public void OpenUrl(string url) => Url = url;
+    }
+
+    [Fact]
+    public void OpenBuildMonitor_OpensExpectedUrl()
+    {
+        var fake = new FakeBrowser();
+        Program.OpenBuildMonitor(fake);
+        Assert.Equal("http://t78.ch/apps/netpipe/", fake.Url);
+    }
+}

--- a/NetProject/BrowserService.vb
+++ b/NetProject/BrowserService.vb
@@ -1,0 +1,23 @@
+' 2025-06-07
+' Provides ability to open URLs in default browser
+' Author: Codex
+' Created: 2025-06-07
+' Edited: 2025-06-07
+
+Imports System.Diagnostics
+
+Public Interface IBrowserService
+    Sub OpenUrl(url As String)
+End Interface
+
+Public Class DefaultBrowserService
+    Implements IBrowserService
+
+    Public Sub OpenUrl(url As String) Implements IBrowserService.OpenUrl
+        Dim startInfo As New ProcessStartInfo With {
+            .FileName = url,
+            .UseShellExecute = True
+        }
+        Process.Start(startInfo)
+    End Sub
+End Class

--- a/NetProject/Program.vb
+++ b/NetProject/Program.vb
@@ -5,6 +5,7 @@
 ' Edited: 2025-06-07
 
 Imports System.Windows.Forms
+Imports System.Diagnostics
 
 Public Module Program
     Private ReadOnly messagePresenter As IMessagePresenter = New MessageBoxPresenter()
@@ -13,6 +14,8 @@ Public Module Program
         ShowGreeting()
         ShowRemoteResult()
     End Sub
+
+    Private Const BuildMonitorUrl As String = "http://t78.ch/apps/netpipe/"
 
     Public Sub ShowGreeting(Optional customPresenter As IMessagePresenter = Nothing)
         Dim greeting As String = "Hallo von Timo 3l!"
@@ -28,5 +31,10 @@ Public Module Program
         Dim resultReader As IResultReader = If(reader, New ResultReader())
         Dim remoteResult As String = resultReader.FetchRemoteResultAsync().Result
         presenter.ShowMessage(remoteResult)
+    End Sub
+
+    Public Sub OpenBuildMonitor(Optional browser As IBrowserService = Nothing)
+        Dim opener As IBrowserService = If(browser, New DefaultBrowserService())
+        opener.OpenUrl(BuildMonitorUrl)
     End Sub
 End Module


### PR DESCRIPTION
## Summary
- add `IBrowserService` and `DefaultBrowserService`
- support opening the build monitor URL via `OpenBuildMonitor`
- test that `OpenBuildMonitor` uses browser service

## Testing
- `apt-get update -y`
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*
- `dotnet test --no-build` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844dacbde9883338ccee177537e1c66