### PR TITLE
Improve debugging messages

### DIFF
--- a/NetProject.Tests/BuildStatusParserTests.cs
+++ b/NetProject.Tests/BuildStatusParserTests.cs
@@ -10,4 +10,20 @@ public class BuildStatusParserTests
         int code = parser.ParseExitCode("some text\nExit code: 1\nnext");
         Assert.Equal(1, code);
     }
+
+    [Fact]
+    public void ParseExitCode_ThrowsWhenPatternMissing()
+    {
+        var parser = new BuildStatusParser();
+        var ex = Assert.Throws<FormatException>(() => parser.ParseExitCode("no exit info"));
+        Assert.Contains("pattern not found", ex.Message);
+    }
+
+    [Fact]
+    public void ParseExitCode_ThrowsWhenValueInvalid()
+    {
+        var parser = new BuildStatusParser();
+        var ex = Assert.Throws<FormatException>(() => parser.ParseExitCode("Exit code: NaN"));
+        Assert.Contains("Failed to parse", ex.Message);
+    }
 }

--- a/NetProject/BuildStatusParser.vb
+++ b/NetProject/BuildStatusParser.vb
@@ -2,22 +2,26 @@
 ' Parses result text into exit codes
 ' Author: Codex
 ' Created: 2025-06-07
-' Edited: 2025-06-07
+' Edited: 2025-06-08
 
 Public Class BuildStatusParser
     Public Function ParseExitCode(content As String) As Integer
         Const pattern As String = "Exit code:"
         Dim index As Integer = content.IndexOf(pattern)
-        If index <> -1 Then
-            index += pattern.Length
-            Dim lineEnd As Integer = content.IndexOfAny(New Char() {Chr(10), Chr(13)}, index)
-            If lineEnd = -1 Then lineEnd = content.Length
-            Dim numberString As String = content.Substring(index, lineEnd - index).Trim()
-            Dim result As Integer
-            If Integer.TryParse(numberString, result) Then
-                Return result
-            End If
+        If index = -1 Then
+            Throw New FormatException("Exit code pattern not found in content.")
         End If
-        Return -1
+
+        index += pattern.Length
+        Dim lineEnd As Integer = content.IndexOfAny(New Char() {Chr(10), Chr(13)}, index)
+        If lineEnd = -1 Then lineEnd = content.Length
+
+        Dim numberString As String = content.Substring(index, lineEnd - index).Trim()
+        Dim result As Integer
+        If Integer.TryParse(numberString, result) Then
+            Return result
+        End If
+
+        Throw New FormatException($"Failed to parse exit code from '{numberString}'.")
     End Function
 End Class

--- a/NetProject/ResultReader.vb
+++ b/NetProject/ResultReader.vb
@@ -2,7 +2,7 @@
 ' Fetches remote build results from NetPipeRemoteDotNet
 ' Author: Codex
 ' Created: 2025-06-07
-' Edited: 2025-06-07
+' Edited: 2025-06-08
 
 Imports System.Net.Http
 Imports System.Threading.Tasks
@@ -18,8 +18,12 @@ Public Class ResultReader
 
     Public Overridable Async Function FetchRemoteResultAsync() As Task(Of String) _
         Implements IResultReader.FetchRemoteResultAsync
-        Dim response As HttpResponseMessage = Await httpClient.GetAsync(ResultUrl)
-        response.EnsureSuccessStatusCode()
-        Return Await response.Content.ReadAsStringAsync()
+        Try
+            Dim response As HttpResponseMessage = Await httpClient.GetAsync(ResultUrl)
+            response.EnsureSuccessStatusCode()
+            Return Await response.Content.ReadAsStringAsync()
+        Catch ex As HttpRequestException
+            Throw New HttpRequestException($"Error fetching remote result from {ResultUrl}: {ex.Message}", ex)
+        End Try
     End Function
 End Class


### PR DESCRIPTION
## Summary
- throw `FormatException` when the exit code is missing or unparsable
- add network error context in `ResultReader`
- cover error cases with new unit tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844dc815724833381634a65cd7dca73