### PR TITLE
Extend build status parsing

### DIFF
--- a/NetProject.Tests/BuildStatusDisplayTests.cs
+++ b/NetProject.Tests/BuildStatusDisplayTests.cs
@@ -36,4 +36,17 @@ public class BuildStatusDisplayTests
 
         Assert.Equal("Exit code: 1, Size: 5", presenter.Message);
     }
+
+    [Fact]
+    public void ShowBuildStatus_IncludesPathIfAvailable()
+    {
+        var content = "Exit code: 1\nFile size: 5\nMapped path: /tmp/test";
+        var reader = new FakeReader(content);
+        var checker = new BuildStatusChecker(reader);
+        var presenter = new FakePresenter();
+
+        Program.ShowBuildStatus(presenter, checker);
+
+        Assert.Equal("Exit code: 1, Size: 5, Path: /tmp/test", presenter.Message);
+    }
 }

--- a/NetProject.Tests/BuildStatusParserTests.cs
+++ b/NetProject.Tests/BuildStatusParserTests.cs
@@ -18,4 +18,20 @@ public class BuildStatusParserTests
         long size = parser.ParseFileSize("info\nFile size: 99 bytes\nend");
         Assert.Equal(99, size);
     }
+
+    [Fact]
+    public void ParseMappedPath_ReturnsString()
+    {
+        var parser = new BuildStatusParser();
+        string path = parser.ParseMappedPath("info\nMapped path: C:/tmp/foo\nend");
+        Assert.Equal("C:/tmp/foo", path);
+    }
+
+    [Fact]
+    public void ParseFileContent_ReturnsRestOfText()
+    {
+        var parser = new BuildStatusParser();
+        string data = parser.ParseFileContent("some\nContent: hello world\n");
+        Assert.Equal("hello world", data);
+    }
 }

--- a/NetProject/BuildStatus.vb
+++ b/NetProject/BuildStatus.vb
@@ -8,11 +8,15 @@ Public Class BuildStatus
     Public ReadOnly Property ExitCode As Integer
     Public ReadOnly Property RawOutput As String
     Public ReadOnly Property FileSize As Long
+    Public ReadOnly Property MappedPath As String
+    Public ReadOnly Property FileContent As String
 
-    Public Sub New(code As Integer, raw As String, Optional size As Long = -1)
+    Public Sub New(code As Integer, raw As String, Optional size As Long = -1, Optional path As String = "", Optional content As String = "")
         ExitCode = code
         RawOutput = raw
         FileSize = size
+        MappedPath = path
+        FileContent = content
     End Sub
 
     Public ReadOnly Property IsSuccess As Boolean

--- a/NetProject/BuildStatusChecker.vb
+++ b/NetProject/BuildStatusChecker.vb
@@ -18,6 +18,8 @@ Public Class BuildStatusChecker
         Dim parser As New BuildStatusParser()
         Dim code As Integer = parser.ParseExitCode(content)
         Dim size As Long = parser.ParseFileSize(content)
-        Return New BuildStatus(code, content, size)
+        Dim path As String = parser.ParseMappedPath(content)
+        Dim fileContent As String = parser.ParseFileContent(content)
+        Return New BuildStatus(code, content, size, path, fileContent)
     End Function
 End Class

--- a/NetProject/BuildStatusParser.vb
+++ b/NetProject/BuildStatusParser.vb
@@ -38,4 +38,26 @@ Public Class BuildStatusParser
         End If
         Return -1
     End Function
+
+    Public Function ParseMappedPath(content As String) As String
+        Const pattern As String = "Mapped path:"
+        Dim index As Integer = content.IndexOf(pattern, StringComparison.OrdinalIgnoreCase)
+        If index <> -1 Then
+            index += pattern.Length
+            Dim lineEnd As Integer = content.IndexOfAny(New Char() {Chr(10), Chr(13)}, index)
+            If lineEnd = -1 Then lineEnd = content.Length
+            Return content.Substring(index, lineEnd - index).Trim()
+        End If
+        Return String.Empty
+    End Function
+
+    Public Function ParseFileContent(content As String) As String
+        Const pattern As String = "Content:"
+        Dim index As Integer = content.IndexOf(pattern, StringComparison.OrdinalIgnoreCase)
+        If index <> -1 Then
+            index += pattern.Length
+            Return content.Substring(index).Trim()
+        End If
+        Return String.Empty
+    End Function
 End Class

--- a/NetProject/Program.vb
+++ b/NetProject/Program.vb
@@ -5,6 +5,7 @@
 ' Edited: 2025-06-08
 
 Imports System.Windows.Forms
+Imports System.Collections.Generic
 
 Public Module Program
     Private ReadOnly messagePresenter As IMessagePresenter = New MessageBoxPresenter()
@@ -35,7 +36,14 @@ Public Module Program
         Dim presenter As IMessagePresenter = If(customPresenter, messagePresenter)
         Dim statusChecker As BuildStatusChecker = If(checker, New BuildStatusChecker())
         Dim status As BuildStatus = statusChecker.GetCurrentStatusAsync().Result
-        Dim message As String = $"Exit code: {status.ExitCode}, Size: {status.FileSize}"
+        Dim parts As New List(Of String) From {
+            $"Exit code: {status.ExitCode}",
+            $"Size: {status.FileSize}"
+        }
+        If Not String.IsNullOrWhiteSpace(status.MappedPath) Then
+            parts.Add($"Path: {status.MappedPath}")
+        End If
+        Dim message As String = String.Join(", ", parts)
         presenter.ShowMessage(message)
     End Sub
 End Module


### PR DESCRIPTION
## Summary
- include mapped path and file contents in `BuildStatus`
- parse `Mapped path:` and `Content:` fields
- display path when showing build status
- add unit tests for path and content parsing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844de0332b0833391b14431f3ae5afc