### PR TITLE
Add basic WPF UI for testing Program features

### DIFF
--- a/NetProject/Application.xaml.vb
+++ b/NetProject/Application.xaml.vb
@@ -1,6 +1,11 @@
-﻿Class Application
+' 2025-06-08
+' WPF application bootstrap class
+' Author: Codex
+' Created: 2025-06-08
+' Edited: 2025-06-08
 
-    ' Application-level events, such as Startup, Exit, and DispatcherUnhandledException
-    ' can be handled in this file.
+Imports System.Windows
 
+Partial Class Application
+    Inherits System.Windows.Application
 End Class

--- a/NetProject/MainWindow.xaml
+++ b/NetProject/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="MainWindow"
+<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -7,6 +7,15 @@
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Grid>
-
+        <StackPanel Margin="10">
+            <Button x:Name="ShowGreetingButton" Content="Show Greeting"
+                    Click="ShowGreetingButton_Click" Margin="0,0,0,5" />
+            <Button x:Name="ShowRemoteResultButton" Content="Show Remote Result"
+                    Click="ShowRemoteResultButton_Click" Margin="0,0,0,5" />
+            <Button x:Name="ShowBuildStatusButton" Content="Show Build Status"
+                    Click="ShowBuildStatusButton_Click" Margin="0,0,0,5" />
+            <TextBox x:Name="OutputBox" Height="150" IsReadOnly="True"
+                     TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" />
+        </StackPanel>
     </Grid>
 </Window>

--- a/NetProject/MainWindow.xaml.vb
+++ b/NetProject/MainWindow.xaml.vb
@@ -1,3 +1,31 @@
-﻿Class MainWindow
+' 2025-06-08
+' Provides interactive UI to test program features
+' Author: Codex
+' Created: 2025-06-08
+' Edited: 2025-06-08
 
+Imports System.Windows
+Imports System.Windows.Controls
+
+Partial Class MainWindow
+    Inherits Window
+
+    Private ReadOnly presenter As WpfOutputPresenter
+
+    Public Sub New()
+        InitializeComponent()
+        presenter = New WpfOutputPresenter(OutputBox)
+    End Sub
+
+    Private Sub ShowGreetingButton_Click(sender As Object, e As RoutedEventArgs)
+        Program.ShowGreeting(presenter)
+    End Sub
+
+    Private Sub ShowRemoteResultButton_Click(sender As Object, e As RoutedEventArgs)
+        Program.ShowRemoteResult(presenter)
+    End Sub
+
+    Private Sub ShowBuildStatusButton_Click(sender As Object, e As RoutedEventArgs)
+        Program.ShowBuildStatus(presenter)
+    End Sub
 End Class

--- a/NetProject/WpfOutputPresenter.vb
+++ b/NetProject/WpfOutputPresenter.vb
@@ -1,0 +1,21 @@
+' 2025-06-08
+' Presents messages inside a WPF TextBox
+' Author: Codex
+' Created: 2025-06-08
+' Edited: 2025-06-08
+
+Imports System.Windows.Controls
+
+Public Class WpfOutputPresenter
+    Implements IMessagePresenter
+
+    Private ReadOnly outputBox As TextBox
+
+    Public Sub New(box As TextBox)
+        outputBox = box
+    End Sub
+
+    Public Sub ShowMessage(message As String) Implements IMessagePresenter.ShowMessage
+        outputBox.Text = message
+    End Sub
+End Class


### PR DESCRIPTION
## Summary
- implement `WpfOutputPresenter` to show text in a `TextBox`
- wire up `Application` and `MainWindow` code-behind for WPF
- add buttons in `MainWindow` to trigger existing functionality

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460c56614483338652d65b83265f78