### PR TITLE
Fix test project reference path

### DIFF
--- a/NetProject.Tests/NetProject.Tests.csproj
+++ b/NetProject.Tests/NetProject.Tests.csproj
@@ -4,7 +4,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\NetProject\NetProject.vbproj" />
+    <ProjectReference Include="../NetProject/NetProject.vbproj" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/NetProject.sln
+++ b/NetProject.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{3AC096D0-A1C2-E12C-1390-A8335801FDAB}") = "NetProject.Tests", "NetProject.Tests\NetProject.Tests.csproj", "{2FB6DE9C-A7EB-48B2-9800-18B049642559}"
+Project("{3AC096D0-A1C2-E12C-1390-A8335801FDAB}") = "NetProject.Tests", "NetProject.Tests/NetProject.Tests.csproj", "{2FB6DE9C-A7EB-48B2-9800-18B049642559}"
 EndProject
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "NetProject", "NetProject\NetProject.vbproj", "{E1463E2B-14E8-464A-BD28-826C57EFE792}"
 EndProject


### PR DESCRIPTION
## Summary
- fix relative path to VB project inside test project
- update solution file to use forward slash path

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684611ef96988333bc0b13daeb806fc4