### PR TITLE
Use WPF message box

### DIFF
--- a/NetProject.TestUI/Application.xaml
+++ b/NetProject.TestUI/Application.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="Application"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/NetProject.TestUI/Application.xaml.vb
+++ b/NetProject.TestUI/Application.xaml.vb
@@ -1,0 +1,11 @@
+' 2025-06-08
+' WPF test application bootstrap
+' Author: Codex
+' Created: 2025-06-08
+' Edited: 2025-06-08
+
+Imports System.Windows
+
+Partial Class Application
+    Inherits System.Windows.Application
+End Class

--- a/NetProject.TestUI/MainWindow.xaml
+++ b/NetProject.TestUI/MainWindow.xaml
@@ -1,0 +1,14 @@
+<Window x:Class="MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:NetProject.TestUI"
+        Title="Test UI" Height="300" Width="400">
+    <Grid>
+        <StackPanel Margin="10">
+            <Button x:Name="ShowGreetingButton" Content="Show Greeting" Margin="0,0,0,5" />
+            <Button x:Name="ShowRemoteResultButton" Content="Show Remote Result" Margin="0,0,0,5" />
+            <Button x:Name="ShowBuildStatusButton" Content="Show Build Status" Margin="0,0,0,5" />
+            <TextBox x:Name="OutputBox" Height="120" IsReadOnly="True" TextWrapping="Wrap" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/NetProject.TestUI/MainWindow.xaml.vb
+++ b/NetProject.TestUI/MainWindow.xaml.vb
@@ -1,0 +1,34 @@
+' 2025-06-08
+' Interactive WPF window for testing
+' Author: Codex
+' Created: 2025-06-08
+' Edited: 2025-06-08
+
+Imports System.Windows
+Imports NetProject
+
+Partial Class MainWindow
+    Inherits Window
+
+    Private ReadOnly presenter As WpfOutputPresenter
+
+    Public Sub New()
+        InitializeComponent()
+        presenter = New WpfOutputPresenter(OutputBox)
+        AddHandler ShowGreetingButton.Click, AddressOf ShowGreeting
+        AddHandler ShowRemoteResultButton.Click, AddressOf ShowRemoteResult
+        AddHandler ShowBuildStatusButton.Click, AddressOf ShowBuildStatus
+    End Sub
+
+    Private Sub ShowGreeting(sender As Object, e As RoutedEventArgs)
+        Program.ShowGreeting(presenter)
+    End Sub
+
+    Private Sub ShowRemoteResult(sender As Object, e As RoutedEventArgs)
+        Program.ShowRemoteResult(presenter)
+    End Sub
+
+    Private Sub ShowBuildStatus(sender As Object, e As RoutedEventArgs)
+        Program.ShowBuildStatus(presenter)
+    End Sub
+End Class

--- a/NetProject.TestUI/NetProject.TestUI.vbproj
+++ b/NetProject.TestUI/NetProject.TestUI.vbproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <RootNamespace>NetProject.TestUI</RootNamespace>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NetProject\NetProject.vbproj" />
+  </ItemGroup>
+</Project>

--- a/NetProject.Tests/ConsoleOutputPresenterTests.cs
+++ b/NetProject.Tests/ConsoleOutputPresenterTests.cs
@@ -1,0 +1,19 @@
+using NetProject;
+using System;
+using System.IO;
+using Xunit;
+
+public class ConsoleOutputPresenterTests
+{
+    [Fact]
+    public void ShowMessage_WritesToConsole()
+    {
+        var presenter = new ConsoleOutputPresenter();
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+
+        presenter.ShowMessage("hello");
+
+        Assert.Equal("hello" + Environment.NewLine, sw.ToString());
+    }
+}

--- a/NetProject.Tests/WpfOutputPresenterTests.cs
+++ b/NetProject.Tests/WpfOutputPresenterTests.cs
@@ -1,0 +1,17 @@
+using NetProject;
+using System.Windows.Controls;
+using Xunit;
+
+public class WpfOutputPresenterTests
+{
+    [Fact]
+    public void ShowMessage_SetsTextBoxText()
+    {
+        var box = new TextBox();
+        var presenter = new WpfOutputPresenter(box);
+
+        presenter.ShowMessage("hi");
+
+        Assert.Equal("hi", box.Text);
+    }
+}

--- a/NetProject.sln
+++ b/NetProject.sln
@@ -7,6 +7,8 @@ Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "NetProject", "NetProject\Ne
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetProject.Tests", "NetProject.Tests\NetProject.Tests.csproj", "{789D2AB2-64AB-0A7F-7D1D-E9F19984F239}"
 EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "NetProject.TestUI", "NetProject.TestUI\NetProject.TestUI.vbproj", "{F2CB3CF4-36F7-494D-8DA2-785806D973F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,8 +22,12 @@ Global
 		{789D2AB2-64AB-0A7F-7D1D-E9F19984F239}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{789D2AB2-64AB-0A7F-7D1D-E9F19984F239}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{789D2AB2-64AB-0A7F-7D1D-E9F19984F239}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{789D2AB2-64AB-0A7F-7D1D-E9F19984F239}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {789D2AB2-64AB-0A7F-7D1D-E9F19984F239}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F2CB3CF4-36F7-494D-8DA2-785806D973F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F2CB3CF4-36F7-494D-8DA2-785806D973F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F2CB3CF4-36F7-494D-8DA2-785806D973F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F2CB3CF4-36F7-494D-8DA2-785806D973F1}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/NetProject/ConsoleOutputPresenter.vb
+++ b/NetProject/ConsoleOutputPresenter.vb
@@ -1,0 +1,13 @@
+' 2025-06-08
+' Writes messages to the console
+' Author: Codex
+' Created: 2025-06-08
+' Edited: 2025-06-08
+
+Public Class ConsoleOutputPresenter
+    Implements IMessagePresenter
+
+    Public Sub ShowMessage(message As String) Implements IMessagePresenter.ShowMessage
+        Console.WriteLine(message)
+    End Sub
+End Class

--- a/NetProject/MessageBoxPresenter.vb
+++ b/NetProject/MessageBoxPresenter.vb
@@ -1,10 +1,10 @@
 ' 2025-06-07
-' Provides message display via Windows Forms MessageBox
+' Provides message display via WPF MessageBox
 ' Author: Codex
 ' Created: 2025-06-07
-' Edited: 2025-06-07
+' Edited: 2025-06-11
 
-Imports System.Windows.Forms
+Imports System.Windows
 
 Public Interface IMessagePresenter
     Sub ShowMessage(message As String)

--- a/NetProject/Program.vb
+++ b/NetProject/Program.vb
@@ -1,10 +1,10 @@
-' 2025-06-08 XXX
+' 2025-06-11
 ' Entry point of application
 ' Author: Codex
 ' Created: 2025-06-07
-' Edited: 2025-06-08
+' Edited: 2025-06-11
 
-Imports System.Windows.Forms
+Imports System.Windows
 Imports System.Collections.Generic
 
 Public Module Program


### PR DESCRIPTION
## Summary
- adjust Program and MessageBoxPresenter to use WPF
- keep project output as WinExe and ensure solution references the WPF test UI

## Testing
- `dotnet test NetProject.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684906acc13483338f7dd6f268c56cf7